### PR TITLE
Fix calculations for resistor values that correspond to negative temperatures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 //! Calculation methods for platinum type RTD temperature sensors.
 //! 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ const B: f32 = -5.7750e-7;
 const C: f32 = -4.1830e-12;
 
 /// Calculate temperature of RTD from resistance value.
-/// 
+///
 /// Allowed temperature range: -200–850°C.
 #[allow(dead_code)]
 pub fn calc_t(r: f32, r_0: RTDType) -> Result<f32, Error> {
@@ -123,7 +123,7 @@ pub fn conv_d_val_to_r(d_val: u32, r_ref: u32, res: ADCRes, pga_gain: u32) -> Re
 #[allow(dead_code)]
 fn poly_correction(r: f32, poly: Polynomial) -> f32 {
     let mut res = 0_f32;
-    for (i, factor) in poly.iter().enumerate() {
+    for (i, factor) in poly.iter().rev().enumerate() {
         res += factor * powf(r, i as f32);
     };    
     res

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,4 +163,26 @@ mod tests {
         dbg!(t);
         assert!(t < 0_f32);
     }
+
+    #[test]
+    fn test_range() {
+        let r_start = 18;
+        let r_end = 390;
+
+        // Calculate the first result
+        let mut prev_result = calc_t(r_start as f32, RTDType::PT100).unwrap();
+
+        for r in r_start + 1..r_end + 1 {
+            let res = calc_t(r as f32, RTDType::PT100).unwrap();
+            dbg!(r, res, prev_result);
+
+            // Result needs to be larger than the previous result
+            assert!(res > prev_result);
+
+            // Check the conversion backwards (calculate resistance value from the temperature result)
+            // Add 0.5 to the resistance to round the result instead of flooring when casting to i32
+            assert_eq!((calc_r(res, RTDType::PT100).unwrap() + 0.5) as i32, r);
+            prev_result = res;
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,4 +154,13 @@ mod tests {
         let t = calc_t(r, RTDType::PT100).unwrap();
         assert_eq!(t, 0_f32);
     }
+
+    #[test]
+    fn negative_temperature() {
+        let r = 99.0;
+
+        let t = calc_t(r, RTDType::PT100).unwrap();
+        dbg!(t);
+        assert!(t < 0_f32);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,15 +165,18 @@ mod tests {
     }
 
     #[test]
-    fn test_range() {
-        let r_start = 18;
-        let r_end = 390;
+    fn test_range_for_all_types() {
+        test_range(18, 390, RTDType::PT100);
+        // FIXME: Add tests for PT200 + PT500 once their polynomials are added
+        test_range(185, 3904, RTDType::PT1000);
+    }
 
+    fn test_range(r_min: i32, r_max: i32, rtd_type: RTDType) {
         // Calculate the first result
-        let mut prev_result = calc_t(r_start as f32, RTDType::PT100).unwrap();
+        let mut prev_result = calc_t(r_min as f32, rtd_type).unwrap();
 
-        for r in r_start + 1..r_end + 1 {
-            let res = calc_t(r as f32, RTDType::PT100).unwrap();
+        for r in r_min + 1..r_max + 1 {
+            let res = calc_t(r as f32, rtd_type).unwrap();
             dbg!(r, res, prev_result);
 
             // Result needs to be larger than the previous result
@@ -181,7 +184,7 @@ mod tests {
 
             // Check the conversion backwards (calculate resistance value from the temperature result)
             // Add 0.5 to the resistance to round the result instead of flooring when casting to i32
-            assert_eq!((calc_r(res, RTDType::PT100).unwrap() + 0.5) as i32, r);
+            assert_eq!((calc_r(res, rtd_type).unwrap() + 0.5) as i32, r);
             prev_result = res;
         }
     }


### PR DESCRIPTION
See #1 for a detailed description.

# TLDR

- Reverse the polynomial iterator in the `poly_correction(...)` function. (5fd0dae5775e408e2c718cfdb0b71c2568f183ff)
    - **I have not checked this for mathematical correctness, just compared the results to existing PT100/PT1000 tables!**
- Add test cases for testing the range of a RTD resistor. (29d58a62f1c679a94d18b6db5c5e8ad9988fa298)
- Add test case that checks that resistor values that should produce negative temperatures actually produce negative temperatures. (f02f4e02e29c2e02460c18cdf3fd67e95f4b8932) + (39267005b5393ef38df2bec0a3538b011f766d58)
