### PR TITLE
Add support for defmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ repository = "https://github.com/thecodechemist99/pt-rtd"
 
 [dependencies]
 libm = "0.2.6"
+defmt = { version = "*", optional = true }
+
+[features]
+defmt = ["dep:defmt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@ fn poly_correction(r: f32, poly: Polynomial) -> f32 {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     OutOfBounds,
     NonexistentType,


### PR DESCRIPTION
Add `defmt` feature which enables the `defmt` dependency and derives `defmt::Format` for the error enum.

This provides logging support for errors when using the `defmt` crate for logging.